### PR TITLE
Adds Street Pharmacist

### DIFF
--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -56,6 +56,9 @@
 	var/spawn_ert = 0
 
 	var/outfit = null
+	var/outfit_male = null
+	var/outfit_female = null
+	var/list/alt_outfits	//Corresponds to alternative titles.
 
 	/////////////////////////////////
 	// /vg/ feature: Job Objectives!
@@ -75,7 +78,24 @@
 	H.species.before_equip_job(src, H, visualsOnly)
 
 	if(outfit)
-		H.equipOutfit(outfit, visualsOnly)
+		var/outfit_equipped = FALSE
+		if(outfit_male && H.gender == MALE)
+			H.equipOutfit(outfit_male, visualsOnly)
+			outfit_equipped = TRUE
+		else if(outfit_female && H.gender == FEMALE)
+			H.equipOutfit(outfit_female, visualsOnly)
+			outfit_equipped = TRUE
+		else if(alt_outfits && H.mind.role_alt_title)
+			var/list/valid_outfits = list()
+			for(var/O in alt_outfits)
+				if(alt_outfits[O] == H.mind.role_alt_title || alt_outfits[O] == "[H.mind.role_alt_title]_male" && H.gender == MALE || alt_outfits[O] == "[H.mind.role_alt_title]_female" && H.gender == FEMALE)
+					valid_outfits += O
+			if(valid_outfits.len)
+				H.equipOutfit(pick(valid_outfits), visualsOnly)
+				outfit_equipped = TRUE
+
+		if(!outfit_equipped)
+			H.equipOutfit(outfit, visualsOnly)
 
 	H.species.after_equip_job(src, H, visualsOnly)
 

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -57,7 +57,7 @@
 	exp_requirements = 180
 	exp_type = EXP_TYPE_CREW
 	outfit = /datum/outfit/job/doctor
-
+	alt_outfits = list(/datum/outfit/job/doctor/surgeon = "Surgeon", /datum/outfit/job/doctor/nurse_1 = "Nurse_female", /datum/outfit/job/doctor/nurse_2 = "Nurse_female", /datum/outfit/job/doctor/nurse_male = "Nurse_male")
 /datum/outfit/job/doctor
 	name = "Medical Doctor"
 	jobtype = /datum/job/doctor
@@ -114,7 +114,7 @@
 					/obj/item/weapon/autopsy_scanner = 1,
 					/obj/item/device/mass_spectrometer = 1,
 					/obj/item/weapon/storage/box/bodybags = 1)
-
+/*
 /datum/outfit/job/doctor/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
 	if(H.mind.role_alt_title)
@@ -133,9 +133,22 @@
 					head = /obj/item/clothing/head/nursehat
 				else
 					uniform = /obj/item/clothing/under/rank/medical/purple
+*/
+/datum/outfit/job/doctor/surgeon
+	uniform = /obj/item/clothing/under/rank/medical/blue
+	head = /obj/item/clothing/head/surgery/blue
 
 
+/datum/outfit/job/doctor/nurse_1
+	uniform = /obj/item/clothing/under/rank/nursesuit
+	head = /obj/item/clothing/head/nursehat
 
+/datum/outfit/job/doctor/nurse_2
+	uniform = /obj/item/clothing/under/rank/nurse
+	head = /obj/item/clothing/head/nursehat
+
+/datum/outfit/job/doctor/nurse_male
+	uniform = /obj/item/clothing/under/rank/medical/purple
 //Chemist is a medical job damnit	//YEAH FUCK YOU SCIENCE	-Pete	//Guys, behave -Erro
 /datum/job/chemist
 	title = "Chemist"
@@ -149,11 +162,12 @@
 	selection_color = "#ffeef0"
 	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics, access_mineral_storeroom)
 	minimal_access = list(access_medical, access_chemistry, access_maint_tunnels, access_mineral_storeroom)
-	alt_titles = list("Pharmacist","Pharmacologist")
+	alt_titles = list("Pharmacist","Pharmacologist","Street Pharmacist")
 	minimal_player_age = 7
 	exp_requirements = 300
 	exp_type = EXP_TYPE_CREW
 	outfit = /datum/outfit/job/chemist
+	alt_outfits = list(/datum/outfit/job/street_pharmacist = "Street Pharmacist")
 
 /datum/outfit/job/chemist
 	name = "Chemist"
@@ -170,6 +184,23 @@
 	backpack = /obj/item/weapon/storage/backpack/chemistry
 	satchel = /obj/item/weapon/storage/backpack/satchel_chem
 	dufflebag = /obj/item/weapon/storage/backpack/duffel/chemistry
+
+/datum/outfit/job/street_pharmacist
+	name = "Street Pharmacist"
+	jobtype = /datum/job/chemist
+	uniform = /obj/item/clothing/under/lawyer/bluesuit
+	suit = /obj/item/clothing/suit/storage/labcoat
+	shoes = /obj/item/clothing/shoes/black
+	l_ear = /obj/item/device/radio/headset/headset_med
+	glasses = /obj/item/clothing/glasses/regular
+	id = /obj/item/weapon/card/id/medical
+	pda = /obj/item/device/pda
+	head = /obj/item/clothing/head/fedora
+
+	backpack = /obj/item/weapon/storage/backpack
+	satchel = /obj/item/weapon/storage/backpack/satchel
+	dufflebag = /obj/item/weapon/storage/backpack/duffel
+
 
 /datum/job/geneticist
 	title = "Geneticist"
@@ -254,12 +285,12 @@
 	minimal_access = list(access_medical, access_psychiatrist, access_maint_tunnels)
 	alt_titles = list("Psychologist","Therapist")
 	outfit = /datum/outfit/job/psychiatrist
-
+	alt_outfits = list(/datum/outfit/job/psychiatrist/psychologist = "Psychologist", /datum/outfit/job/psychiatrist/therapist = "Therapist")
 /datum/outfit/job/psychiatrist
 	name = "Psychiatrist"
 	jobtype = /datum/job/psychiatrist
 
-	uniform = /obj/item/clothing/under/rank/medical
+	uniform = /obj/item/clothing/under/rank/psych
 	suit = /obj/item/clothing/suit/storage/labcoat
 	shoes = /obj/item/clothing/shoes/laceup
 	l_ear = /obj/item/device/radio/headset/headset_med
@@ -267,6 +298,13 @@
 	suit_store = /obj/item/device/flashlight/pen
 	pda = /obj/item/device/pda/medical
 
+/datum/outfit/job/psychiatrist/psychologist
+	uniform = /obj/item/clothing/under/rank/psych/turtleneck
+
+/datum/outfit/job/psychiatrist/therapist
+	uniform = /obj/item/clothing/under/rank/medical
+
+/*
 /datum/outfit/job/psychiatrist/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
 	if(H.mind.role_alt_title)
@@ -277,6 +315,7 @@
 				uniform = /obj/item/clothing/under/rank/psych/turtleneck
 			if("Therapist")
 				uniform = /obj/item/clothing/under/rank/medical
+*/
 
 /datum/job/paramedic
 	title = "Paramedic"

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -103,7 +103,6 @@
 	supervisors = "the head of security"
 	department_head = list("Head of Security")
 	selection_color = "#ffeeee"
-	alt_titles = list("Forensic Technician")
 	access = list(access_security, access_sec_doors, access_forensics_lockers, access_morgue, access_maint_tunnels, access_court, access_weapons)
 	minimal_access = list(access_sec_doors, access_forensics_lockers, access_morgue, access_maint_tunnels, access_court, access_weapons)
 	alt_titles = list("Forensic Technician")
@@ -111,6 +110,7 @@
 	exp_requirements = 300
 	exp_type = EXP_TYPE_CREW
 	outfit = /datum/outfit/job/detective
+	alt_outfits = list(/datum/outfit/job/detective/forensic_technician = "Forensic Technician")
 
 /datum/outfit/job/detective
 	name = "Detective"
@@ -135,6 +135,10 @@
 
 	implants = list(/obj/item/weapon/implant/mindshield)
 
+/datum/outfit/job/detective/forensic_technician
+	suit = /obj/item/clothing/suit/storage/det_suit/forensics/blue
+	head = null
+/*
 /datum/outfit/job/detective/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
 	if(H.mind.role_alt_title)
@@ -142,7 +146,7 @@
 			if("Forensic Technician")
 				suit = /obj/item/clothing/suit/storage/det_suit/forensics/blue
 				head = null
-
+*/
 /datum/outfit/job/detective/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
 	if(visualsOnly)

--- a/data/mode.txt
+++ b/data/mode.txt
@@ -1,1 +1,1 @@
-secret
+extended


### PR DESCRIPTION
Per Bast's request, the Chemist now has another alternate title, the Street Pharmacist. Not being one to do things by half-measures, I decided to give him a special outfit and to standardize all the relevant code. Another blow has been struck against rampant overloading! As a result, you can now define alternate outfits for alternate titles, as well as gender-specific getups. This has been tested, and no obvious bugs have been found. Cheers!

![image](https://user-images.githubusercontent.com/10413301/50808033-9b911a00-12b1-11e9-94f7-ef021ec3a015.png)
